### PR TITLE
Fix the KernelRequest event object name

### DIFF
--- a/src/EventListener/AddRequestFormatsListener.php
+++ b/src/EventListener/AddRequestFormatsListener.php
@@ -3,7 +3,7 @@
 namespace Erelke\TwigSpreadsheetBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -12,9 +12,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class AddRequestFormatsListener implements EventSubscriberInterface
 {
     /**
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         $event->getRequest()->setFormat('csv', 'text/csv');
         $event->getRequest()->setFormat('ods', 'application/vnd.oasis.opendocument.spreadsheet');


### PR DESCRIPTION
Updated to use new event name (https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching)